### PR TITLE
Add pivot functionality to Model

### DIFF
--- a/src/Structures/Model.php
+++ b/src/Structures/Model.php
@@ -412,13 +412,14 @@ class Model implements \ArrayAccess, \Iterator, \Countable {
             }
         }
         //Fill in any gaps with nulls
-        for ($i=0; $i<count($expanded); $i++){
-            for ($j=0; $j<count($pivotColumns); $j++){
-                if (!isset($expanded[$i][$pivotColumns[$j]])){
-                    $expanded[$i][$pivotColumns[$j]] = null;
+        foreach($expanded as $idx=>$value){
+            for ($i=0; $i<$rowCount; $i++){
+                if (!isset($expanded[$idx][$pivotColumns[$j]])){
+                    $expanded[$idx][$pivotColumns[$j]] = null;
                 }
             }
         }
+
         $outputModel->_data = $expanded;
         return $outputModel;
     }

--- a/src/Structures/Model.php
+++ b/src/Structures/Model.php
@@ -394,7 +394,7 @@ class Model implements \ArrayAccess, \Iterator, \Countable {
             $row = $this->_data[$i];
             $currentIdx = $row[$indexColumn];
             if (!isset($expanded[$currentIdx])){
-                $expanded[$currentIdx] = [];
+                $expanded[$currentIdx] = [$indexColumn => $currentIdx]; //This is redundant for now, but allows us to reindex the array when we're done
             }
             if (isset($flippedColumns[$row[$pivotBy]])){
                 if (isset($expanded[$currentIdx][$row[$pivotBy]])){
@@ -419,6 +419,8 @@ class Model implements \ArrayAccess, \Iterator, \Countable {
                 }
             }
         }
+        //Reindex results sequentially
+        $expanded = array_values($expanded);
 
         $outputModel->_data = $expanded;
         return $outputModel;

--- a/src/Structures/Model.php
+++ b/src/Structures/Model.php
@@ -38,7 +38,7 @@ class Model implements \ArrayAccess, \Iterator, \Countable {
                 }
             }
             $this->_diff = new Diff('{}');
-            $this->select();
+            if (isset($this->_select)) $this->select();
     }
     
     // Countable implementation

--- a/src/Structures/Model.php
+++ b/src/Structures/Model.php
@@ -350,7 +350,7 @@ class Model implements \ArrayAccess, \Iterator, \Countable {
         if (count($pivotByColumn) == 0){
             throw new VeloxException("Specified pivot-by column '$pivotBy' does not exist in result set.",68);
         }
-        $pivotByValues = array_unique($pivotByColumn);
+        $pivotByValues = array_values(array_unique($pivotByColumn));
 
         //Check if $indexColumn column exists in data set
         $indexValues = array_unique(array_column($this->_data,$indexColumn));
@@ -412,9 +412,9 @@ class Model implements \ArrayAccess, \Iterator, \Countable {
             }
         }
         //Fill in any gaps with nulls
-        foreach($expanded as $idx=>$value){
+        foreach($expanded as $idx=>$row){
             for ($i=0; $i<count($pivotColumns); $i++){
-                if (!isset($value[$pivotColumns[$i]])){
+                if (!isset($row[$pivotColumns[$i]])){
                     $expanded[$idx][$pivotColumns[$i]] = null;
                 }
             }

--- a/src/Structures/Model.php
+++ b/src/Structures/Model.php
@@ -414,7 +414,7 @@ class Model implements \ArrayAccess, \Iterator, \Countable {
         //Fill in any gaps with nulls
         foreach($expanded as $idx=>$value){
             for ($i=0; $i<count($pivotColumns); $i++){
-                if (!isset($expanded[$idx][$pivotColumns[$i]])){
+                if (!isset($value[$pivotColumns[$i]])){
                     $expanded[$idx][$pivotColumns[$i]] = null;
                 }
             }

--- a/src/Structures/Model.php
+++ b/src/Structures/Model.php
@@ -27,7 +27,6 @@ class Model implements \ArrayAccess, \Iterator, \Countable {
         private PreparedStatement|StatementSet|Transaction|null $_delete = null,
         public ?string                                          $instanceName = null){
             $props = ["_select","_update","_insert","_delete"];
-            $conn = $this->_select->conn ?? $this->_update->conn ?? $this->_insert->conn ?? $this->_delete->conn;
             foreach($props as $prop){
                 if (isset($this->$prop)){
                     if ($this->$prop->queryType != Query::QUERY_PROC){

--- a/src/Structures/Model.php
+++ b/src/Structures/Model.php
@@ -327,6 +327,102 @@ class Model implements \ArrayAccess, \Iterator, \Countable {
             }
         }
     }
+    public function pivot(string $pivotBy, string $indexColumn, string $valueColumn, array $pivotColumns = null, bool $ignore = false, bool $suppressColumnException = false) : Model {
+        // This method performs a pivot-like operation on the current data and returns the result as a new Model.
+        //
+        // Arguments (in order):
+        //   $pivotBy (required)                 - a string containing the name of the column to be pivoted (containing the intended column names)
+        //   $indexColumn (required)             - a string containing the name of the column to be used as an index (the values by which the pivot results will
+        //                                         be grouped)
+        //   $valueColumn (required)             - a string containing the name of the column in which the pivoted data values are to be found
+        //   $pivotColumns (optional)            - an array of specific values from $pivotBy (i.e., intended columns) to be used; all others will be ignored
+        //                                         (if not provided, all unique values from the $pivotBy column will be used)
+        //   $ignore (optional)                  - if set to true, $pivotColumns is instead treated as a list of columns to be ignored, and all others are included
+        //   $suppressColumnException (optional) - if set to true, no exception will be thrown if one or more of the $pivotColumns do not exist in the original dataset;
+        //                                         instead, the missing columns will be included with their values set to null
+
+        $outputModel = new Model;
+        $rowCount = count($this->_data);
+        if ($rowCount == 0){
+            return $outputModel; //Don't bother trying to pivot an empty Model; just return
+        }
+        //Check if $pivotBy column exists in data set
+        $pivotByColumn = array_column($this->_data,$pivotBy);
+        if (count($pivotByColumn) == 0){
+            throw new VeloxException("Specified pivot-by column '$pivotBy' does not exist in result set.",68);
+        }
+        $pivotByValues = array_unique($pivotByColumn);
+
+        //Check if $indexColumn column exists in data set
+        $indexValues = array_unique(array_column($this->_data,$indexColumn));
+        if (count($indexValues) == 0){
+            throw new VeloxException("Index column '$indexColumn' does not exist in result set.",69);
+        }
+        if (is_null($pivotColumns)){
+            $pivotColumns = $pivotByValues;
+        }
+        if ($ignore){
+            $pivotColumns = array_diff($pivotByValues,$pivotColumns);
+        }
+
+        //Check if $valueColumn column exists in data set
+        $values = array_column($this->_data,$valueColumn);
+        if (count($values) == 0){
+            throw new VeloxException("Value column '$valueColumn' does not exist in result set.",70);
+        }
+
+        //Check whether all given columns exist in the $pivotBy column
+        $diff = array_diff($pivotColumns,$pivotByValues);
+        if (count($diff) > 0 && !$suppressColumnException){
+            throw new VeloxException("Value(s) ".implode(",",$diff)." specified in pivot columns array do not exist in $pivotBy column.",71);
+        }
+
+        $flippedColumns = array_flip($pivotColumns);
+        foreach ($flippedColumns as $name=>$type){
+            $flippedColumns[$name] = false; //Does the column contain any text? Default is false until non-numeric data is found
+        }
+
+        //Iterate once through the rows to determine if any of the above needs to be set to true
+        for ($i=0; $i<$rowCount; $i++){
+            $row = $this->_data[$i];
+            if (!$flippedColumns[$row[$pivotBy]] && !is_numeric($row[$valueColumn])){
+                $flippedColumns[$row[$pivotBy]] = true;
+            }
+        }
+
+        $expanded = [];
+        for ($i=0; $i<$rowCount; $i++){
+            $row = $this->_data[$i];
+            $currentIdx = $row[$indexColumn];
+            if (!isset($expanded[$currentIdx])){
+                $expanded[$currentIdx] = [];
+            }
+            if (isset($flippedColumns[$row[$pivotBy]])){
+                if (isset($expanded[$currentIdx][$row[$pivotBy]])){
+                    //summation depends on column data type - numbers should be added and everything else should be concatenated
+                    if ($flippedColumns[$row[$pivotBy]]){
+                        $expanded[$currentIdx][$row[$pivotBy]] .= ",".$row[$valueColumn];
+                    }
+                    else {
+                        $expanded[$currentIdx][$row[$pivotBy]] += $row[$valueColumn];
+                    }
+                }
+                else {
+                    $expanded[$currentIdx][$row[$pivotBy]] = $row[$valueColumn];
+                }
+            }
+        }
+        //Fill in any gaps with nulls
+        for ($i=0; $i<count($expanded); $i++){
+            for ($j=0; $j<count($pivotColumns); $j++){
+                if (!isset($expanded[$i][$pivotColumns[$j]])){
+                    $expanded[$i][$pivotColumns[$j]] = null;
+                }
+            }
+        }
+        $outputModel->_data = $expanded;
+        return $outputModel;
+    }
     public function lastQuery() : ?int {
         return $this->_lastQuery;
     }

--- a/src/Structures/Model.php
+++ b/src/Structures/Model.php
@@ -414,8 +414,8 @@ class Model implements \ArrayAccess, \Iterator, \Countable {
         //Fill in any gaps with nulls
         foreach($expanded as $idx=>$value){
             for ($i=0; $i<$rowCount; $i++){
-                if (!isset($expanded[$idx][$pivotColumns[$j]])){
-                    $expanded[$idx][$pivotColumns[$j]] = null;
+                if (!isset($expanded[$idx][$pivotColumns[$i]])){
+                    $expanded[$idx][$pivotColumns[$i]] = null;
                 }
             }
         }

--- a/src/Structures/Model.php
+++ b/src/Structures/Model.php
@@ -413,7 +413,7 @@ class Model implements \ArrayAccess, \Iterator, \Countable {
         }
         //Fill in any gaps with nulls
         foreach($expanded as $idx=>$value){
-            for ($i=0; $i<$rowCount; $i++){
+            for ($i=0; $i<count($pivotColumns); $i++){
                 if (!isset($expanded[$idx][$pivotColumns[$i]])){
                     $expanded[$idx][$pivotColumns[$i]] = null;
                 }

--- a/src/Structures/Model.php
+++ b/src/Structures/Model.php
@@ -16,7 +16,7 @@ class Model implements \ArrayAccess, \Iterator, \Countable {
     private object $_diff;
     private Diff|array|null $_filter = null;
     private array $_filteredIndices = [];
-    private int|null $_lastQuery;
+    private int|null $_lastQuery = null;
     private bool $_delaySelect = false;
     private int $_currentIndex = 0;
     


### PR DESCRIPTION
The Model::pivot() method allows rows to be pivoted as columns. MySQL does not provide native functionality for this, so any results that require pivoting can first be queried with a normal Model; once this is done, Model::pivot() will return a new Model containing the pivoted results.