### PR TITLE
Renamed Diff to VeloxQL

### DIFF
--- a/src/Database/Procedures/StatementSet.php
+++ b/src/Database/Procedures/StatementSet.php
@@ -6,7 +6,7 @@ namespace KitsuneTech\Velox\Database\Procedures;
 use KitsuneTech\Velox\VeloxException;
 use KitsuneTech\Velox\Database\Connection as Connection;
 use KitsuneTech\Velox\Database\Procedures\{Query, Transaction};
-use KitsuneTech\Velox\Structures\{Diff, ResultSet};
+use KitsuneTech\Velox\Structures\{VeloxQL, ResultSet};
 use function KitsuneTech\Velox\Utility\{recur_ksort, isAssoc};
 
 /** `StatementSet` is a class that dynamically generates a collection of related PreparedStatements. This is best used for
@@ -70,11 +70,11 @@ class StatementSet implements \Countable, \Iterator, \ArrayAccess {
     /** @param Connection   $conn       The Connection instance to use for this instance
      *  @param string       $_baseSql   The SQL template by which to generate the prepared statements
      *  @param int|null     $queryType  The type of query to be run ({@see Query::QUERY_SELECT QUERY_SELECT, etc.})
-     *  @param array|Diff   $criteria   Initial criteria to be applied; this can be used to avoid having to call setCriteria() later
+     *  @param array|VeloxQL   $criteria   Initial criteria to be applied; this can be used to avoid having to call setCriteria() later
      *  @param string|null  $name       The name of this StatementSet; can be used to distinguish between multiple StatementSets in a single Transaction
      *  @throws VeloxException          If criteria are incorrectly formatted (see exception text for description)
      */
-    public function __construct(public Connection &$conn, private string $_baseSql = "", public ?int $queryType = null, public array|Diff $criteria = [], public ?string $name = null){
+    public function __construct(public Connection &$conn, private string $_baseSql = "", public ?int $queryType = null, public array|VeloxQL $criteria = [], public ?string $name = null){
         $lc_query = strtolower($this->_baseSql);
         if (str_starts_with($lc_query,"call")){
             throw new VeloxException("Stored procedure calls are not supported by StatementSet.",46);
@@ -98,7 +98,7 @@ class StatementSet implements \Countable, \Iterator, \ArrayAccess {
                 $this->queryType = Query::QUERY_SELECT;
             }
         }
-        if ($this->criteria instanceof Diff || count($this->criteria) > 0){
+        if ($this->criteria instanceof VeloxQL || count($this->criteria) > 0){
             $this->addCriteria($this->criteria);
         }
     }
@@ -173,12 +173,12 @@ class StatementSet implements \Countable, \Iterator, \ArrayAccess {
      * Adds criteria to the StatementSet. These criteria are the values and/or conditions that will be used to create and
      * execute the prepared statements based on the base SQL template and its <<placeholders>>.
      *
-     * @param array|Diff $criteria  The criteria to be added
+     * @param array|VeloxQL $criteria  The criteria to be added
      * @return void
      * @throws VeloxException       If criteria are incorrectly formatted (see exception text for description)
      */
-    public function addCriteria(array|Diff $criteria) : void {
-        if ($criteria instanceof Diff){
+    public function addCriteria(array|VeloxQL $criteria) : void {
+        if ($criteria instanceof VeloxQL){
             switch ($this->queryType){
                 case Query::QUERY_SELECT:
                     $this->addCriteria($criteria->select);

--- a/src/Structures/Diff.php
+++ b/src/Structures/Diff.php
@@ -3,28 +3,7 @@ declare(strict_types=1);
 
 namespace KitsuneTech\Velox\Structures;
 
-class Diff {
-    public array $select;
-    public array $update;
-    public array $insert;
-    public array $delete;
-    public function __construct(string $json = ""){
-        //Expected JSON format (where col1 is an autoincrement field not set by this library):
-        //(each row is an object with properties representing each field name)
-        // {
-        //  select:
-        //    [{where: [{col1: ["=","someValue"]}],
-        //  insert:
-        //    [{values: {col2: 'data', col3: 'data'},{col2: 'moredata', col3: 'moredata'}}],
-        //  delete:
-        //    [{where: [{col1: 1},{col2: 'deleteThis', col3: 'deleteThis'}]],
-        //  update:
-        //    [{values: {col2: 'changeThis'}, where: {col2: 'fromThis'}},{values: {col2: 'thisToo'}, where: {col1: 2}}]
-        // }
-        $diffObj = $json != "" ? json_decode($json) : (object)[];
-        $this->select = $diffObj->select ?? [];
-        $this->update = $diffObj->update ?? [];
-        $this->insert = $diffObj->insert ?? [];
-        $this->delete = $diffObj->delete ?? [];
-    }
+class_alias(VeloxQL::class, Diff::class);
+if (false){
+    class Diff extends VeloxQL {}
 }

--- a/src/Structures/Model.php
+++ b/src/Structures/Model.php
@@ -14,7 +14,7 @@ class Model implements \ArrayAccess, \Iterator, \Countable {
     private array $_columns = [];
     private array $_data = [];
     private object $_diff;
-    private Diff|array|null $_filter = null;
+    private VeloxQL|array|null $_filter = null;
     private array $_filteredIndices = [];
     private int|null $_lastQuery = null;
     private bool $_delaySelect = false;
@@ -37,7 +37,7 @@ class Model implements \ArrayAccess, \Iterator, \Countable {
                     }
                 }
             }
-            $this->_diff = new Diff('{}');
+            $this->_diff = new VeloxQL('{}');
             if (isset($this->_select)) $this->select();
     }
     
@@ -95,7 +95,7 @@ class Model implements \ArrayAccess, \Iterator, \Countable {
 
     
     // Class-specific methods
-    public function select(bool $diff = false) : Diff|bool {
+    public function select(bool $diff = false) : VeloxQL|bool {
         if (!$this->_select){
             throw new VeloxException('The associated procedure for select has not been defined.',37);
         }
@@ -126,7 +126,7 @@ class Model implements \ArrayAccess, \Iterator, \Countable {
             }
             
             if ($diff) {
-                $this->_diff = new Diff();
+                $this->_diff = new VeloxQL();
                 foreach ($this->_data as $index => $row){
                     if (!in_array($row,$results)){
                         unset($this->_data[$index]);
@@ -154,8 +154,8 @@ class Model implements \ArrayAccess, \Iterator, \Countable {
 
     private function executeDML(string $verb, array $rows) : bool {
         //$rows is expected to be an array of associative arrays. If the associated update object is a PreparedStatement, each element must be
-        // an array of parameter sets ["placeholder"=>"value"]; if the update object is a StatementSet, the array should be Diff-like (each element
-        // having "values" and "where" keys with the appropriate structure [see the comments in php/Structures/Diff.php].
+        // an array of parameter sets ["placeholder"=>"value"]; if the update object is a StatementSet, the array should be VeloxQL-like (each element
+        // having "values" and "where" keys with the appropriate structure [see the comments in php/Structures/VeloxQL.php].
 
         //This method is not called directly. Rather, each of the three DML methods (insert, update, delete) calls it with the appropriate verb.
 
@@ -251,7 +251,7 @@ class Model implements \ArrayAccess, \Iterator, \Countable {
         array_multisort(...$sortArray);
     }
     
-    public function synchronize(Diff $diff) : void {
+    public function synchronize(VeloxQL $diff) : void {
         $this->_delaySelect = true;
         if ($diff->update) {
             $this->update($diff->update);
@@ -279,11 +279,11 @@ class Model implements \ArrayAccess, \Iterator, \Countable {
             return $this->_data;
         }
     }
-    public function diff() : Diff {
+    public function diff() : VeloxQL {
         return $this->_diff;
     }
-    public function setFilter(Diff|array|null $filter = null) : void {
-        $this->_filter = $filter instanceof Diff ? $filter->select : (!is_null($filter) ? $filter : []);
+    public function setFilter(VeloxQL|array|null $filter = null) : void {
+        $this->_filter = $filter instanceof VeloxQL ? $filter->select : (!is_null($filter) ? $filter : []);
         $this->_filteredIndices = [];
         if (!$this->_filter){
             return;

--- a/src/Structures/VeloxQL.php
+++ b/src/Structures/VeloxQL.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace KitsuneTech\Velox\Structures;
+
+class VeloxQL {
+    public array $select;
+    public array $update;
+    public array $insert;
+    public array $delete;
+    public function __construct(string $json = ""){
+        //Expected JSON format (where col1 is an autoincrement field not set by this library):
+        //(each row is an object with properties representing each field name)
+        // {
+        //  select:
+        //    [{where: [{col1: ["=","someValue"]}],
+        //  insert:
+        //    [{values: {col2: 'data', col3: 'data'},{col2: 'moredata', col3: 'moredata'}}],
+        //  delete:
+        //    [{where: [{col1: 1},{col2: 'deleteThis', col3: 'deleteThis'}]],
+        //  update:
+        //    [{values: {col2: 'changeThis'}, where: {col2: 'fromThis'}},{values: {col2: 'thisToo'}, where: {col1: 2}}]
+        // }
+        $diffObj = $json != "" ? json_decode($json) : (object)[];
+        $this->select = $diffObj->select ?? [];
+        $this->update = $diffObj->update ?? [];
+        $this->insert = $diffObj->insert ?? [];
+        $this->delete = $diffObj->delete ?? [];
+    }
+}
+
+class_exists(VeloxQL::class);


### PR DESCRIPTION
Diff might be a confusing nomenclature for this object, given what "diff" means in terms of databases. VeloxQL hints more at the class's function -- as an object analog to SQL meant to be fed to a Model to filter or manipulate its contents. 

Diff remains as a deprecated alias to VeloxQL, but will eventually be removed.